### PR TITLE
feat: add support for service account annotations

### DIFF
--- a/sanity-tests/test-cases/agent-trigger-service-account.yaml
+++ b/sanity-tests/test-cases/agent-trigger-service-account.yaml
@@ -1,0 +1,5 @@
+agentTrigger:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/my-role
+      

--- a/templates/agent-trigger-service-account.yml
+++ b/templates/agent-trigger-service-account.yml
@@ -2,3 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: agent-trigger-service-account
+  {{- with .Values.agentTrigger.serviceAccount.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -152,6 +152,18 @@
     "agentTrigger": {
       "description": "Agent trigger for triggering deployments",
       "properties": {
+        "serviceAccount": {
+          "description": "Agent trigger service account configuration",
+          "properties": {
+            "annotations": {
+              "description": "Service account annotations",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "limits": {
           "description": "Limits on the container",
           "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -11,6 +11,8 @@ agentTrigger:
     memory: 1000Mi
   requests:
     memory: 1000Mi
+  serviceAccount:
+    annotations: {}
 #requests:
 #  cpu: 200m
 #  memory: 500Mi


### PR DESCRIPTION
## Summary
This PR adds support for annotations on the agent-trigger ServiceAccount, enabling integrations such as IRSA (IAM Roles for Service Accounts) on EKS.

## Main changes
Added agentTrigger.serviceAccount.annotations field in values.yaml.
Added schema validation in values.schema.json, ensuring it is an object with string values.
Added metadata.annotations block in the templates/agent-trigger-service-account.yml.
Added a test case sanity-tests/test-cases/agent-trigger-service-account.yaml with an example AWS annotation (eks.amazonaws.com/role-arn).

## Motivation
Allow chart users to add custom annotations to the agent-trigger ServiceAccount.
Facilitate integration with cloud identity providers (e.g., AWS IRSA).

## Impact
No impact on existing users (default is {}).
Users can now configure custom annotations if needed.